### PR TITLE
Get version of module that has been set for install/uninstall routines

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -194,7 +194,7 @@ class RockMigrations extends WireData implements Module {
    * @return void
    */
   public function executeInstall() {
-  	// check if module is set
+    // check if module is set
     if(!$this->module) throw new WireException("Please set the module first: setModule(\$yourmodule)");
 
     $version = $this->modules->getModuleInfo($this->module)['version'];
@@ -208,7 +208,7 @@ class RockMigrations extends WireData implements Module {
    * @return void
    */
   public function executeUninstall() {
-  	// check if module is set
+    // check if module is set
     if(!$this->module) throw new WireException("Please set the module first: setModule(\$yourmodule)");
 
     $version = $this->modules->getModuleInfo($this->module)['version'];

--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -194,8 +194,12 @@ class RockMigrations extends WireData implements Module {
    * @return void
    */
   public function executeInstall() {
-    $version = self::getModuleInfo()['version'];
-    return $this->executeUpgrade(null, $version);
+  	// check if module is set
+    if(!$this->module) throw new WireException("Please set the module first: setModule(\$yourmodule)");
+
+    $version = $this->modules->getModuleInfo($this->module)['version'];
+    $versionStr = $this->modules->formatVersion($version);
+    return $this->executeUpgrade(null, $versionStr);
   }
   
   /**
@@ -204,8 +208,12 @@ class RockMigrations extends WireData implements Module {
    * @return void
    */
   public function executeUninstall() {
-    $version = self::getModuleInfo()['version'];
-    return $this->executeUpgrade($version, null);
+  	// check if module is set
+    if(!$this->module) throw new WireException("Please set the module first: setModule(\$yourmodule)");
+
+    $version = $this->modules->getModuleInfo($this->module)['version'];
+    $versionStr = $this->modules->formatVersion($version);
+    return $this->executeUpgrade($versionStr, null);
   }
 
   /**


### PR DESCRIPTION
Hi! 👋 Thanks for this module 😃 

I've been taking it for a test drive on a site, and wanted to take advantage of the module install/uninstall hooks. Using the Demo module as a starting point, I created a `SiteMigrations` module, at version 1.0.0, but couldn't get the migrations to run.

The log file contained this: 

`Executing upgrade    -->   0.0.6 for module SiteMigrations`

It seems like the `executeInstall()` and `executeUninstall()` methods were looking at the module version for RockMigrations itself, rather than the `$this->module` that was passed to `setModule()`. Working now for me at install/uninstall time with the changes in this PR.

The PR code gets the version number string from the PW Modules class, and passes that value to the `executeUpgrade()` method.

Hope I've understood the intentions and behaviours correctly!