### PR TITLE
Move setFieldData after setTemplateData has been run

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1600,11 +1600,13 @@ class RockMigrations extends WireData implements Module {
 
     // setup fields
     foreach($config->fields as $name=>$data) $this->createField($name, $data['type']);
-    foreach($config->fields as $name=>$data) $this->setFieldData($name, $data);
-
+    
     // setup templates
     foreach($config->templates as $name=>$data) $this->createTemplate($name, false);
     foreach($config->templates as $name=>$data) $this->setTemplateData($name, $data, true);
+
+    // setup field data (after templates in case they are reference template settings)
+    foreach($config->fields as $name=>$data) $this->setFieldData($name, $data);
 
     // setup pages
     foreach($config->pages as $name=>$data) {


### PR DESCRIPTION
If you have page field that needs to set template_id value based on the template that is created in same migration it doesn't work currently (since template is created after fields). This simple PR fixes that. 