### PR TITLE
Add support for ProFields: table

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -668,6 +668,12 @@ class RockMigrations extends WireData implements Module {
           $fg->saveContext();
         }
       }
+      
+      // Make sure Table field actually updates database schema
+      if ($field->type == "FieldtypeTable") {
+        $fieldtypeTable = $field->getFieldtype();
+        $fieldtypeTable->_checkSchema($field, true); // Commit changes
+      }
 
       $field->save();
       return $field;


### PR DESCRIPTION
Powerful ProFields: table -field only requires this small addition to work. Here is example field to test:

```
'invoice_rows' => [
	'type' => 'table',
	'label' => 'Invoice rows',
	'maxCols' => 4,
	'col1name' => 'product',
	'col1label' => 'Product',
	'col1type' => 'pageAutocomplete',
	'col1selector' => 'template=product',
	'col2name' => 'total_amount',
	'col2label' => 'Total amount',
	'col2type' => 'decimal',
	'col3name' => 'net_amount',
	'col3label' => 'Net amount',
	'col3type' => 'decimal',
	'col4name' => 'vat_amount',
	'col4label' => 'VAT amount',
	'col4type' => 'decimal',
]
```