### PR TITLE
fix installation of modules

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -1643,18 +1643,18 @@ class RockMigrations extends WireData implements Module {
      *
      * @param string $name
      * @param string $url
-     * @return void
+     * @return Module
      */
     public function installModule($name, $url = null) {
       // if the module is already installed we return it
-      $module = $this->modules->get((string)$name);
+      $module = $this->modules->get((string)$name); // this is not good because getting a module will also install it, so if the files are on disk they are installed
       if($module) return $module;
 
       // if an url was provided, download the module
       if($url) $this->downloadModule($url);
 
       // install and return the module
-      return $this->modules->install($name);
+      return $this->modules->install($name, array('force' => true));
     }
 
     /**


### PR DESCRIPTION
To install the module you need to force it, a problem I also tackled in ModulesManager 2.
Now if you do `$this->rm()->installModule('SeoMaestro', 'https://github.com/wanze/SeoMaestro/archive/master.zip');` it works!

Another hint: for line 1648:  `$module = $this->modules->get((string)$name); // this is not good because getting a module will also install it if the files are on disk `.
See the reference here: https://processwire.com/api/ref/modules/get/

It is better to use `$modules->isInstalled('ModuleName')` to pre-check.

You could have a look at ModulesManager2 https://github.com/jmartsch/processwire-modules-manager2/blob/master/ModulesManager2.module.php  where I tackled lots of these problems.