### PR TITLE
Fix getfield method

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -837,6 +837,7 @@ class RockMigrations extends WireData implements Module {
      * @return mixed
      */
     public function getField($name, $exception = null) {
+      if (is_null($name) OR $name === '') return false; // return early if $name is null or an empty string
       if($name AND !is_string($name) AND !$name instanceof Field) {
         $func = @debug_backtrace()[1]['function'];
         throw new WireException("Invalid type set for field in $func");

--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -846,7 +846,7 @@ class RockMigrations extends WireData implements Module {
 
       // return field when found or no exception
       if($field) return $field;
-      if($exception === false) return;
+      if($exception === false) return false;
 
       // field was not found, throw exception
       if(!$exception) $exception = "Field $name not found";


### PR DESCRIPTION
When running one of my migrations I get an error which says that the ID of a field could not be retrieved.
When I dumped the $name of the field it turns out it is often "null" or an empty string. So I fixed this an return early. 
This also makes this function faster.

Also a correct return value (boolean) false is returned, if the field can not be retrieved.

I hope, that this commit has no issues with the code formatting.