### PR TITLE
Ability to specify more pages with the same name declaratively.

### DIFF
--- a/RockMigrations.module.php
+++ b/RockMigrations.module.php
@@ -2492,7 +2492,9 @@ class RockMigrations extends WireData implements Module {
 
     // setup pages
     foreach($config->pages as $name=>$data) {
-      if(is_int($name)) {
+      if(isset($data['name'])) {
+        $name = $data['name'];
+      } elseif(is_int($name)) {
         // no name provided
         $name = uniqid();
       }


### PR DESCRIPTION
The problem is there could be more pages with the same name but different parents, and the associative array won't allow you to have multiple keys of the same name. So you have to put the name in page's data and don't use the associative array like this:

```
'pages' => [
    [
        'name' => 'xyz',
        'parent' => '/abc',
        ...
    ],
    [
        'name' => 'xyz',
        'parent' => '/cde'
        ...
    ]
]
```

But this way RM will create a new page with random ID every time and then set its proper name.